### PR TITLE
Automate package installation in Vagrant

### DIFF
--- a/toolchain/vagrant/README.md
+++ b/toolchain/vagrant/README.md
@@ -2,15 +2,9 @@
 
 ## Installation
 
-### First install the vagrant package.
+### Provision the Vagrant environment and SSH into it:
 
     $ vagrant up && vagrant ssh
-
-
-### Now from inside the VM:
-
-    $ bash /vagrant/installPackages.sh
-    $ source ~/.bash_profile
 
 
 ## Notes
@@ -19,8 +13,3 @@
 * The Anaconda installation is done with Miniconda, which is a very barebones intallation.  If you want to add additional packages to the install script, you can modify the "installPackages.sh" file.  
 * If you want to run a Jupyter Notebook, you can run "jupyter notebook" at the command line. You will then be able to access the notebook from the host browser at localhost:8888.
 * These setup files were set up using Vagrant v1.8.6 and VirtualBox v5.1.6.  Earlier, unsuccessful, attempts were made with Vagrant v1.7 and VirtualBox v4.  If you have older versions of Vagrant or Virtualbox, you may have to upgrade.
-
-
-Annoyances:
-
-1. It seems like there should be a way to accomplish the last source command as part of the script but I don't know how to do it.

--- a/toolchain/vagrant/Vagrantfile
+++ b/toolchain/vagrant/Vagrantfile
@@ -14,6 +14,9 @@ Vagrant.configure("2") do |config|
   # boxes at https://atlas.hashicorp.com/search.
   config.vm.box = "bento/ubuntu-16.04"
 
+  # Run the 'installPackages.sh' script as the vagrant user.
+  config.vm.provision :shell, path: 'installPackages.sh', privileged: false
+
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
   # `vagrant box outdated`. This is not recommended.

--- a/toolchain/vagrant/installPackages.sh
+++ b/toolchain/vagrant/installPackages.sh
@@ -1,20 +1,22 @@
 #!/bin/bash
 
+LOGFILE=~/installPackages.log
+
 echo "Installing Miniconda..."
-bash /vagrant/Miniconda3-latest-Linux-x86_64.sh -b
+bash /vagrant/Miniconda3-latest-Linux-x86_64.sh -b >> $LOGFILE
 echo "# Added for Miniconda" >> ~/.bash_profile
 echo "export PATH=\"$HOME/miniconda3/bin:\$PATH\"" >> ~/.bash_profile
 
 . ~/.bash_profile
 
 echo "Installing Jupyter..."
-conda install -y jupyter
+conda install -y jupyter >> $LOGFILE
 
 echo "Installing Pandas..."
-conda install -y pandas
+conda install -y pandas >> $LOGFILE
 
 echo "Installing scikit and seaborn..."
-conda install -y seaborn scikit-learn
+conda install -y seaborn scikit-learn >> $LOGFILE
 
 mkdir ~/.jupyter
 cp /vagrant/jupyter_notebook_config.py ~/.jupyter

--- a/toolchain/vagrant/installPackages.sh
+++ b/toolchain/vagrant/installPackages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Installing Miniconda..."
-/vagrant/Miniconda3-latest-Linux-x86_64.sh -b
+bash /vagrant/Miniconda3-latest-Linux-x86_64.sh -b
 echo "# Added for Miniconda" >> ~/.bash_profile
 echo "export PATH=\"$HOME/miniconda3/bin:\$PATH\"" >> ~/.bash_profile
 
@@ -16,7 +16,7 @@ conda install -y pandas
 echo "Installing scikit and seaborn..."
 conda install -y seaborn scikit-learn
 
-mkdir .jupyter
-cp /vagrant/jupyter_notebook_config.py .jupyter
+mkdir ~/.jupyter
+cp /vagrant/jupyter_notebook_config.py ~/.jupyter
 
-echo "Installation complete" 
+echo "Installation complete"


### PR DESCRIPTION
Changed ```Vagrantfile``` to automatically run ```installPackages.sh```, and modified ```README.md``` to reflect the shorter installation instructions.

In order for it to work for me, I also had to change line 4 of ```installPackages.sh``` from
```
/vagrant/Miniconda3-latest-Linux-x86_64.sh -b
```
back to
```
bash /vagrant/Miniconda3-latest-Linux-x86_64.sh -b
```

The ```bash``` was recently removed in commit [```c4a0428```](https://github.com/hackoregon/hack-university-data-architecture/commit/c4a042880713daba47ce5b75b0fd9b8faedf40b3), but I am unsure of the reason for the change, and was unable to get it to work without it there.

The output by from ```installPackages.sh``` is much uglier when run through Vagrant, but I tested to make sure everything installs and runs, and that ```PATH``` is correct on first boot. Everything appears to work correctly.